### PR TITLE
[Bug fix]runName option is updated by the groupId environment variable

### DIFF
--- a/src/lib/cypress-testrail-reporter.ts
+++ b/src/lib/cypress-testrail-reporter.ts
@@ -36,7 +36,7 @@ export class CypressTestRailReporter extends reporters.Spec {
     }
 
     if (process.env.CYPRESS_TESTRAIL_REPORTER_GROUPID) {
-      this.reporterOptions.runName = process.env.CYPRESS_TESTRAIL_REPORTER_GROUPID;
+      this.reporterOptions.groupId = process.env.CYPRESS_TESTRAIL_REPORTER_GROUPID;
     }
 
     if (process.env.CYPRESS_TESTRAIL_REPORTER_REFS) {


### PR DESCRIPTION
## WHAT
SSIA

## WHY
Implemented in this PR
https://github.com/Vivify-Ideas/cypress-testrail-reporter/pull/21/files#diff-aeadd254df62a2442804f395ecde42d0ab620f7c88dc44ff495a72b20d6a1fd6R38